### PR TITLE
Add PCI Radeon 7000 series state

### DIFF
--- a/src/configuration/graphics.md
+++ b/src/configuration/graphics.md
@@ -50,9 +50,9 @@ Similar things as above apply.
 
 ### Radeon 7000 series
 
-**Interface:** AGP  
+**Interface:** PCI, AGP  
 **OpenGL:** 1.3  
-**Works:** With issues/in practice no  
+**Works:** Yes, AGP may have issues  
 **KMS:** Yes  
 **3D acceleration:** Yes  
 **2D acceleration:** X11  


### PR DESCRIPTION
If someone with an AGP version of this card could test again on kernel 5.x, PCI is completely fine on X11.